### PR TITLE
Add CI building and auto deployment to GitHub Container Registry

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,48 @@
+name: Continuous Deployment
+
+on:
+  push:
+    branches:
+      - 'master'
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+      - 'master'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Log in to the Container registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build Docker image (and push, for releases)
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,21 @@
 FROM fedora:34
+LABEL org.opencontainers.image.source=https://github.com/GSConnect/gsconnect-ci
 
-RUN dnf install -y glibc-langpack-en
+RUN dnf -y install glibc-langpack-en && \
+	dnf clean all && \
+	rm -rf /var/cache/dnf
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8
 ENV LC_ALL en_US.UTF-8
 
-RUN dnf install -y appstream gcc gettext git glib2-devel gnome-shell \
-                   gnome-desktop-testing lcov meson npm xorg-x11-server-Xvfb \
-                   zip && \
-    dnf clean all && \
-    rm -rf /var/cache/yum
+RUN dnf -y install \
+		appstream gcc gettext git glib2-devel gnome-shell \
+		gnome-desktop-testing lcov meson npm \
+		xorg-x11-server-Xvfb zip && \
+	dnf clean all && \
+	rm -rf /var/cache/dnf
 
 # Install eslint
-RUN npm install -g eslint
+RUN npm install -g eslint && \
+	npm cache rm
 

--- a/README.md
+++ b/README.md
@@ -4,17 +4,42 @@ Docker image for [GSConnect][gsconnect] CI.
 
 [gsconnect]: https://github.com/andyholmes/gnome-shell-extension-gsconnect
 
+## GitHub Container Registry
 
-## Create and publish a new image
+Images are automatically deployed from release tags/branches
+to the GitHub Container Registry.
 
-```sh
-$ git clone git@github.com:GSConnect/gsconnect-ci.git
-$ cd gsconnect-ci
-$ git checkout -b ${GNOME_VERSION}
-$ # Edit Dockerfile - probably to bump Fedora version
-$ git push -u origin ${GNOME_VERSION}
-$ podman build -t gsconnect/gsconnect-ci:${GNOME_VERSION} .
-# docker build -t gsconnect/gsconnect-ci:${GNOME_VERSION} .
-$ podman push gsconnect/gsconnect-ci:${GNOME_VERSION}
-# docker push gsconnect/gsconnect-ci:${GNOME_VERSION}
+The latest image will be listed under "Packages" on the repo homepage.
+
+To use from another GitHub Actions workflow:
+
+```yaml
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/gsconnect/gsconnect-ci:latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Prep environment
+        run: >
+          meson --prefix=/usr
+                --libdir=lib/
+                -Dgnome_shell_libdir=/usr/lib
+                -Dpost_install=true
+                _build
+
+      - name: Run uninstalled tests
+        run: >
+          meson test -C _build
+                --suite gsconnect:data
+                --suite gsconnect:lint
+                --print-errorlogs
+
+      - name: Run installed tests
+        run: |
+          ninja -C _build install
+          xvfb-run -a dbus-run-session -- \
+            gnome-desktop-testing-runner gsconnect -L _build/meson-logs
 ```


### PR DESCRIPTION
This PR adds a `publish.yml` workflow to automatically build new images for open PRs (CI), as well as automatically deploying to the GitHub Container Registry for any pushed release branch/tag (CD). It makes heavy use of [official GitHub Actions from Docker](https://github.com/marketplace?type=actions&query=publisher%3Adocker).

#### GHCR Deployment

By taking advantage of the closed loop of GitHub's ecosystem, images can be deployed automatically without requiring any additional credentials beyond the standard `${{ secrets.GITHUB_TOKEN }}` provided during all GitHub Actions workflow runs.

On the downstream end, consuming the image from the Container Registry is just a matter of replacing this:
```yaml
jobs:
  build:
    runs_on: ubuntu:latest
    container:
      image: gsconnect/gsconnect-ci
```
with this:
```yaml
jobs:
  build:
    runs_on: ubuntu:latest
    container:
      image: ghcr.io/gsconnect/gsconnect-ci:latest
```

#### Container access

By default, new packages published to the Container Registry are private. To make them available downstream, there are two options:

1. After the first package is published, a repo admin goes into the Packages listing for the repo, selects the package, clicks Package Settings, and grants `gsconnect/gnome-shell-extensions-gsconnect` read-only access to the published image. The downstream workflow will need to log in to the GHCR with its default credentials:
    ```yaml
    container:
      image: ghcr.io/gsconnect/gsconnect-ci:latest
      credentials:
        username: ${{ github.actor }}
        password: ${{ secrets.GITHUB_TOKEN }}
    ```

1. After the first package is published, a repo admin goes into the Packages listing for the repo, selects the package, clicks Package Settings, and uses the Change Visibility button at the bottom of the page to make the package Public. No credentials are required in the downstream workflow.

#### Other GNOME versions

Publishing additional images for other GNOME versions isn't currently implemented, but could easily be as [docker/metadata-action](https://github.com/docker/metadata-action) is extremely customizable.
