### PR TITLE
Dockerfile: fix npm-cache operation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,5 +17,5 @@ RUN dnf -y install \
 
 # Install eslint
 RUN npm install -g eslint && \
-	npm cache rm
+	npm cache clean --force
 


### PR DESCRIPTION
The CI reported an error cleaning the cache, suggesting `npm cache verify` or
requiring the `--force` option to `npm cache rm`.

Since the intended result was probably to remove the cache for the download,
choose the latter and use the canonical command name `clean`.