### PR TITLE
Pare down install set

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
 FROM fedora:34
 LABEL org.opencontainers.image.source=https://github.com/GSConnect/gsconnect-ci
 
-RUN dnf -y install glibc-langpack-en && \
+RUN dnf --setopt install_weak_deps=false -y install glibc-langpack-en && \
 	dnf clean all && \
 	rm -rf /var/cache/dnf
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8
 ENV LC_ALL en_US.UTF-8
 
-RUN dnf -y install \
+RUN dnf --setopt install_weak_deps=false -y install \
 		appstream gcc gettext git glib2-devel gnome-shell \
 		gnome-desktop-testing lcov meson npm \
 		xorg-x11-server-Xvfb zip && \


### PR DESCRIPTION
Eliminating weak package dependencies from the `dnf install` commands cuts a hundred or so packages from the install set, and around 250MB from the final image size, with no impact on GSConnect's CI.

(Makes sense, as this is the list of packages being dropped. "Nothing of value was lost.")

```text
#7 48.58 Installing weak dependencies:
#7 48.58  NetworkManager-wifi                  x86_64  1:1.32.12-2.fc35                 updates  116 k
#7 48.58  abattis-cantarell-fonts              noarch  0.301-5.fc35                     updates  364 k
#7 48.58  adobe-source-code-pro-fonts          noarch  2.030.1.050-11.fc35              fedora   831 k
#7 48.58  diffutils                            x86_64  3.8-1.fc35                       fedora   400 k
#7 48.58  exiv2                                x86_64  0.27.5-1.fc35                    updates  976 k
#7 48.58  flatpak                              x86_64  1.12.7-1.fc35                    updates  1.5 M
#7 48.58  gnome-color-manager                  x86_64  3.36.0-6.fc35                    fedora   1.1 M
#7 48.58  gnome-remote-desktop                 x86_64  41.2-1.fc35                      updates  149 k
#7 48.58  gnome-session-xsession               x86_64  41.3-1.fc35                      updates   13 k
#7 48.58  gnome-tour                           x86_64  41~rc-1.fc35                     fedora   676 k
#7 48.58  grubby                               x86_64  8.40-55.fc35                     fedora    35 k
#7 48.58  hunspell-en                          noarch  0.20140811.1-20.fc35             fedora   180 k
#7 48.58  jxl-pixbuf-loader                    x86_64  0.6.1-6.fc35                     updates   54 k
#7 48.58  kpartx                               x86_64  0.8.6-5.fc35                     fedora    49 k
#7 48.58  libbpf                               x86_64  2:0.4.0-2.fc35                   fedora   131 k
#7 48.58  logrotate                            x86_64  3.18.1-2.fc35                    fedora    75 k
#7 48.58  memstrack                            x86_64  0.2.4-1.fc35                     updates   50 k
#7 48.58  mesa-dri-drivers                     x86_64  21.3.7-1.fc35                    updates   26 M
#7 48.58  nm-connection-editor                 x86_64  1.24.0-1.fc35                    fedora   823 k
#7 48.58  nodejs-docs                          noarch  1:16.14.0-2.fc35                 updates  6.7 M
#7 48.58  nodejs-full-i18n                     x86_64  1:16.14.0-2.fc35                 updates  8.1 M
#7 48.58  p11-kit-server                       x86_64  0.23.22-4.fc35                   fedora   190 k
#7 48.58  perl-IO-Socket-SSL                   noarch  2.072-1.fc35                     fedora   217 k
#7 48.58  perl-Mozilla-CA                      noarch  20211001-1.fc35                  updates   12 k
#7 48.58  perl-NDBM_File                       x86_64  1.15-482.fc35                    updates   30 k
#7 48.58  pigz                                 x86_64  2.5-2.fc35                       fedora    81 k
#7 48.58  pinentry-gnome3                      x86_64  1.2.0-1.fc35                     fedora    40 k
#7 48.58  pipewire-alsa                        x86_64  0.3.48-1.fc35                    updates   62 k
#7 48.58  pipewire-jack-audio-connection-kit   x86_64  0.3.48-1.fc35                    updates  134 k
#7 48.58  power-profiles-daemon                x86_64  0.10.1-2.fc35                    updates   54 k
#7 48.58  qrencode-libs                        x86_64  4.1.1-1.fc35                     updates   60 k
#7 48.58  rygel                                x86_64  0.40.3-1.fc35                    updates  1.1 M
#7 48.58  systemd-networkd                     x86_64  249.9-1.fc35                     updates  524 k
#7 48.58  systemd-resolved                     x86_64  249.9-1.fc35                     updates  268 k
#7 48.58  tracker-miners                       x86_64  3.2.2-1.fc35                     updates  875 k
#7 48.58  xdg-desktop-portal-gnome             x86_64  41.1-1.fc35                      fedora   146 k
