### PR TITLE
Dockerfile: bump image to fedora:36 for GNOME 42

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:34
+FROM fedora:36
 LABEL org.opencontainers.image.source=https://github.com/GSConnect/gsconnect-ci
 
 RUN dnf --setopt install_weak_deps=false -y install glibc-langpack-en && \
@@ -9,8 +9,8 @@ ENV LANGUAGE en_US.UTF-8
 ENV LC_ALL en_US.UTF-8
 
 RUN dnf --setopt install_weak_deps=false -y install \
-		appstream gcc gettext git glib2-devel gnome-shell \
-		gnome-desktop-testing lcov meson npm \
+		appstream desktop-file-utils gcc gettext git glib2-devel \
+		gnome-shell gnome-desktop-testing lcov meson npm \
 		xorg-x11-server-Xvfb zip && \
 	dnf clean all && \
 	rm -rf /var/cache/dnf


### PR DESCRIPTION
Bump the base image to `fedora:36` for the updated meson version and
add `desktop-file-utils` to the image.