### PR TITLE
Add Python linters to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ ENV LC_ALL en_US.UTF-8
 
 RUN dnf --setopt install_weak_deps=false -y install \
 		appstream desktop-file-utils gcc gettext git glib2-devel \
-		gnome-shell gnome-desktop-testing meson npm \
-		xorg-x11-server-Xvfb zip && \
+		gnome-shell gnome-desktop-testing meson npm python3 \
+		python3-pip xorg-x11-server-Xvfb zip && \
 	dnf clean all && \
 	rm -rf /var/cache/dnf
 
@@ -19,3 +19,5 @@ RUN dnf --setopt install_weak_deps=false -y install \
 RUN npm install -g eslint && \
 	npm cache clean --force
 
+# Install Python linting tools
+RUN python3 -m pip --no-cache-dir --no-input install black flake8


### PR DESCRIPTION
This PR follows on from GSConnect/gnome-shell-extension-gsconnect#1512 which would add the ability to run Python lint checks on the `nautilus-gsconnect.py` source. To run those checks from the CI container, it needs the tools.