### PR TITLE
Switch to fedora:40 for GNOME 46

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:38
+FROM fedora:40
 LABEL org.opencontainers.image.source=https://github.com/GSConnect/gsconnect-ci
 
 RUN dnf --setopt install_weak_deps=false -y install glibc-langpack-en && \


### PR DESCRIPTION
Fedora 40 (currently in beta) is the first version to include the `GioUnix` introspection files; in GNOME 46 it appears that some parts of `Gio` have been split out.

See:
* GSConnect/gnome-shell-extension-gsconnect#1781
* GSConnect/gnome-shell-extension-gsconnect#1782