### PR TITLE
Add additional eslint flat-config dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN dnf --setopt install_weak_deps=false -y install \
     rm -rf /var/cache/dnf
 
 # Install eslint
-RUN npm install -g eslint @eslint/js && \
+RUN npm install -g eslint globals @eslint/js @eslint/eslintrc && \
         npm cache clean --force
 
 # Install Python linting tools


### PR DESCRIPTION
This PR adds the additional modules (`globals` and `@eslint/eslintrc`) required to use the new `eslint.config.js` format config file.