### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions" 
+    directory: "/" 
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Configure for weekly version-update checks on dependencies. (Meaning, actions used in workflow files, for `github-actions`, and dependencies found in the Dockerfile, for `docker`.)

I noticed some of our Actions dependencies here were out of date (most of the `docker-*` actions are at least one version beyond what we're using), and GitHub's recent [announcement](https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/) that they're going to be sending some older actions versions down the deprecation → "brownout" → removal pipeline reminded me we should be keeping this stuff up to date.