### PR TITLE
CI: Allow building & tagging 'gnome/*' branches

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,11 +4,13 @@ on:
   push:
     branches:
       - 'main'
+      - 'gnome/*'
     tags:
       - 'v*'
   pull_request:
     branches:
       - 'main'
+      - 'gnome/*'
 
 env:
   REGISTRY: ghcr.io
@@ -29,6 +31,12 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=edge,branch=main
+            type=ref,event=branch
+            type=sha
+            # set latest tag for default branch
+            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Log in to the Container registry
         if: github.event_name != 'pull_request'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 FROM fedora:41
-LABEL org.opencontainers.image.source=https://github.com/GSConnect/gsconnect-ci
+LABEL org.opencontainers.image.source="https://github.com/GSConnect/gsconnect-ci" org.gsconnect.gnome.version="47"
 
 RUN dnf --setopt install_weak_deps=false -y install glibc-langpack-en && \
-	dnf clean all && \
-	rm -rf /var/cache/dnf
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US.UTF-8
-ENV LC_ALL en_US.UTF-8
+    dnf clean all && \
+    rm -rf /var/cache/dnf
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8
 
 RUN dnf --setopt install_weak_deps=false -y install \
         appstream \
@@ -30,7 +30,7 @@ RUN dnf --setopt install_weak_deps=false -y install \
 
 # Install eslint
 RUN npm install -g eslint globals @eslint/js @eslint/eslintrc && \
-        npm cache clean --force
+    npm cache clean --force
 
 # Install Python linting tools
 RUN python3 -m pip --no-cache-dir --no-input install black flake8


### PR DESCRIPTION
If I've got this right, update the CI to also allow building of local `gnome/*` branches, and automatically (via the `tags: type=ref,event=branch` parameter to `docker/metadata-action`) tag them so that e.g. builds from branch `gnome/43` will be tagged `gnome-43`.

(After this is merged, I plan to create branches with Dockerfiles customized to be based on Fedora releases that correspond to the required GNOME versions.)
